### PR TITLE
Belt Shield for V3 Board

### DIFF
--- a/Belt Shield for V3 Board
+++ b/Belt Shield for V3 Board
@@ -1,0 +1,4 @@
+STL files :
+BeltShield_Battery.STL
+BeltShield_Bottom.STL
+BeltShield_Top.STL


### PR DESCRIPTION
A shield for OpenBCI electronic card V3 to attach on a belt, to 3D-print.
